### PR TITLE
Param binding

### DIFF
--- a/infrataster-plugin-mysql.gemspec
+++ b/infrataster-plugin-mysql.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "infrataster", "~> 0.2.6"
-  spec.add_runtime_dependency "mysql2"
+  spec.add_runtime_dependency "mysql2-cs-bind"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/infrataster/contexts/mysql_query_context.rb
+++ b/lib/infrataster/contexts/mysql_query_context.rb
@@ -17,7 +17,7 @@ module Infrataster
             username: options[:user],
             password: options[:password],
           )
-          client.query(resource.query)
+          client.xquery(resource.query, *resource.params)
         end
       end
     end

--- a/lib/infrataster/contexts/mysql_query_context.rb
+++ b/lib/infrataster/contexts/mysql_query_context.rb
@@ -1,5 +1,5 @@
 require 'infrataster'
-require 'mysql2'
+require 'mysql2-cs-bind'
 
 module Infrataster
   module Contexts

--- a/lib/infrataster/resources/mysql_query_resource.rb
+++ b/lib/infrataster/resources/mysql_query_resource.rb
@@ -5,15 +5,16 @@ module Infrataster
     class MysqlQueryResource < BaseResource
       Error = Class.new(StandardError)
 
-      attr_reader :query
+      attr_reader :query, :params
 
-      def initialize(query, options = {})
+      def initialize(query, *args)
         @query = query
-        @options = options
+        @options = args.last.is_a?(Hash) ? args.pop : {}
+        @params = args
       end
 
       def to_s
-        "mysql '#{@query}'"
+        "mysql '#{@query}' with #{@params}"
       end
     end
   end

--- a/spec/mysql_query_spec.rb
+++ b/spec/mysql_query_spec.rb
@@ -7,5 +7,13 @@ describe server(:db) do
       expect(row['Value'].to_i).to be > 0
     end
   end
+
+  describe mysql_query('SELECT User, Host FROM mysql.user WHERE User=? AND Host=?', 'app', '%') do
+    it 'binds arguments to query' do
+      row = results.first
+      expect(row['User']).to eq 'app'
+      expect(row['Host']).to eq '%'
+    end
+  end
 end
 


### PR DESCRIPTION
Hello, 

It is sometimes bothering to escape parameters in query properly. So, I wrote a patch for that.

By this patch, we become to able to write queries with parameters like this:

```ruby
describe server(:db) do
  describe mysql_query('SELECT User, Host from mysql.user WHERE User=? AND Host=?', 'app', '%') do
    it '...' do
      # ...
    end
  end
end
```

Could you consider this?
Thank you.