### PR TITLE
Update runtime dependency for infrataster

### DIFF
--- a/infrataster-plugin-mysql.gemspec
+++ b/infrataster-plugin-mysql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "infrataster", "~> 0.1.8"
+  spec.add_runtime_dependency "infrataster", ">= 0.1.8"
   spec.add_runtime_dependency "mysql2"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Hi,

Current infrataster-plugin-mysql has runtime dependency for 0.1 infrataster.
Due to this, bundle install in example of infrataster installs  version 0.1.0 infrataster-plugin-mysql plugin.
The plugin uses removed method of Server class and causes test cause failure.
Would you please update runtime_dependency for infrataster in gemspec file?

```
  1) server 'db' from 'app' mysql 'SHOW STATUS' responds uptime
     Failure/Error: row = results.find {|r| r['Variable_name'] == 'Uptime' }
     NoMethodError:
       undefined method `open_gateway_on_from_server' for #<Infrataster::Server:0x007fd0646c52a0>
     # ./vendor/bundle/ruby/2.0.0/gems/infrataster-plugin-mysql-0.1.0/lib/infrataster/contexts/mysql_query_context.rb:13:in `results'
```