### PR TITLE
Specify most recent version of infrataster (0.2.6) as runtime dependency

### DIFF
--- a/infrataster-plugin-mysql.gemspec
+++ b/infrataster-plugin-mysql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "infrataster", "~> 0.1.8"
+  spec.add_runtime_dependency "infrataster", "~> 0.2.6"
   spec.add_runtime_dependency "mysql2"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Fixes https://github.com/ryotarai/infrataster-plugin-mysql/issues/5

This works fine when I tested it locally.