### PR TITLE
update runtime dependency for infrataster 0.3.0

### DIFF
--- a/infrataster-plugin-mysql.gemspec
+++ b/infrataster-plugin-mysql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "infrataster", "~> 0.2.6"
+  spec.add_runtime_dependency "infrataster", "~> 0.3.0"
   spec.add_runtime_dependency "mysql2-cs-bind"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Infrataster has been updated to 0.3.0.
But the dependency of infrataster-plugin-mysql for infrataster is still ~>0.2.6.
So the latest infrataster-plugin-mysql is not installed with the latest infrataster.

The problem is just its dependency, i think.
So I suggest this pull request.

I don't change the spec.version because I don't know about your rule of it.

thank you.