### PR TITLE
Allow changing options in the mysql_query resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Infrataster::Server.define(
 )
 ```
 
+These options can also be changed in the `mysql_query` resource:
+
+```ruby
+describe server(:db) do
+  describe mysql_query('SELECT User, Host FROM user WHERE User=? AND Host=?', 'app', '%', database: 'mysql') do
+    it 'binds arguments to query' do
+      row = results.first
+      expect(row['User']).to eq 'app'
+      expect(row['Host']).to eq '%'
+    end
+  end
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/infrataster-plugin-mysql/fork )

--- a/lib/infrataster/contexts/mysql_query_context.rb
+++ b/lib/infrataster/contexts/mysql_query_context.rb
@@ -9,6 +9,7 @@ module Infrataster
         if server.options[:mysql]
           options = options.merge(server.options[:mysql])
         end
+        options = options.merge(resource.options)
 
         server.forward_port(options[:port]) do |address, new_port|
           mysql_options = {
@@ -19,7 +20,6 @@ module Infrataster
             mysql_options[:database] = options[:database]
           end
           client = Mysql2::Client.new(mysql_options)
-
           client.xquery(resource.query, *resource.params)
         end
       end

--- a/lib/infrataster/resources/mysql_query_resource.rb
+++ b/lib/infrataster/resources/mysql_query_resource.rb
@@ -5,7 +5,7 @@ module Infrataster
     class MysqlQueryResource < BaseResource
       Error = Class.new(StandardError)
 
-      attr_reader :query, :params
+      attr_reader :query, :params, :options
 
       def initialize(query, *args)
         @query = query

--- a/spec/mysql_query_spec.rb
+++ b/spec/mysql_query_spec.rb
@@ -15,6 +15,16 @@ describe server(:db) do
       expect(row['Host']).to eq '%'
     end
   end
+
+  describe 'changing database name option in mysql_query resource' do
+    describe mysql_query('SELECT User, Host FROM user WHERE User=? AND Host=?', 'app', '%', database: 'mysql') do
+      it 'binds arguments to query' do
+        row = results.first
+        expect(row['User']).to eq 'app'
+        expect(row['Host']).to eq '%'
+      end
+    end
+  end
 end
 
 describe server(:db_database_name) do


### PR DESCRIPTION
Options passes to the resource are currently unused. This change is to merge these options with the options used to connect to the database, allowing us to change connection options in the `mysql_query` resource.

Summarizing, this allows us to do things like the following:

```ruby
describe server(:db) do
  describe mysql_query('SELECT ...', database: 'myapp') do
    # [...]
  end
end
```